### PR TITLE
fix(QuestionTypeChoiceChart): add darkmode for ticks and bar colors

### DIFF
--- a/src/components/QuestionTypeChoiceChart.js
+++ b/src/components/QuestionTypeChoiceChart.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react'
-import {
-  fontFamilies,
-  colors
-} from '@project-r/styleguide'
+import { fontFamilies, colors, useColorContext } from '@project-r/styleguide'
 import { css } from 'glamor'
 import CheckCircle from 'react-icons/lib/md/check-circle'
 
@@ -16,28 +13,24 @@ const styles = {
   bars: css({
     display: 'flex',
     width: '100%',
-    height: HEIGHT
+    height: HEIGHT,
+  }),
+  barTick: css({
+    position: 'relative',
+    height: HEIGHT,
+    width: '1px',
   }),
   left: css({
     width: '50%',
-    borderLeftColor: 'rgba(0,0,0,0.17)',
-    borderLeftWidth: '1px',
-    borderLeftStyle: 'solid',
-    borderRightColor: 'rgba(0,0,0,0.17)',
-    borderRightWidth: '1px',
-    borderRightStyle: 'solid',
-    position: 'relative'
+    position: 'relative',
   }),
   right: css({
     width: '50%',
-    borderRightColor: 'rgba(0,0,0,0.17)',
-    borderRightWidth: '1px',
-    borderRightStyle: 'solid',
-    position: 'relative'
+    position: 'relative',
   }),
   bar: css({
     position: 'absolute',
-    top: (HEIGHT-BAR_HEIGHT)/2,
+    top: (HEIGHT - BAR_HEIGHT) / 2,
     height: BAR_HEIGHT,
     whiteSpace: 'nowrap',
   }),
@@ -54,84 +47,123 @@ const styles = {
     fontFamily: fontFamilies.sansSerifRegular,
     fontWeight: 'normal',
     fontSize: 12,
-    color: '#979797'
+    color: '#979797',
   }),
   label: css({
     whiteSpace: 'nowrap',
-    marginBottom: 1
+    marginBottom: 1,
   }),
   userAnswerIcon: css({
-    marginBottom: 4
-  })
+    marginBottom: 4,
+  }),
 }
 
-class Chart extends Component {
-  render () {
-    const { question, t } = this.props
-    if (!question || !question.choiceResults) {
-      return null
-    }
+const Chart = (props) => {
+  const [colorScheme] = useColorContext()
+  const { question, t } = props
+  if (!question || !question.choiceResults) {
+    return null
+  }
 
-    const { turnout: { submitted }, choiceResults: results, userAnswer } = question
-    const trueResult = results.find( r => r.option.value == 'true')
-    const falseResult = results.find( r => r.option.value == 'false')
-    const userAnswerTrue = userAnswer && userAnswer.payload.value[0] == 'true'
-    const userAnswerFalse = userAnswer && userAnswer.payload.value[0] == 'false'
+  const {
+    turnout: { submitted },
+    choiceResults: results,
+    userAnswer,
+  } = question
+  const trueResult = results.find((r) => r.option.value == 'true')
+  const falseResult = results.find((r) => r.option.value == 'false')
+  const userAnswerTrue = userAnswer && userAnswer.payload.value[0] == 'true'
+  const userAnswerFalse = userAnswer && userAnswer.payload.value[0] == 'false'
 
-    const getPercentage = (result) =>
-      submitted > 0
-      ? Math.round(100/submitted*result.count)
-      : 0
+  const getPercentage = (result) =>
+    submitted > 0 ? Math.round((100 / submitted) * result.count) : 0
 
-    const truePercent = getPercentage(trueResult)
-    const falsePercent = getPercentage(falseResult)
+  const truePercent = getPercentage(trueResult)
+  const falsePercent = getPercentage(falseResult)
 
-    return (
-      <div style={{ width: '100%' }}>
-        <div {...styles.labels} style={{ justifyContent: 'space-around' }}>
-          <label>{t.pluralize('questionnaire/question/choice/votes', { count: submitted })}</label>
-        </div>
-        <div {...styles.bars}>
-          <div {...styles.left}>
-            <div {...styles.bar} style={{
+  return (
+    <div style={{ width: '100%' }}>
+      <div {...styles.labels} style={{ justifyContent: 'space-around' }}>
+        <label>
+          {t.pluralize('questionnaire/question/choice/votes', {
+            count: submitted,
+          })}
+        </label>
+      </div>
+      <div {...styles.bars}>
+        <div
+          {...styles.barTick}
+          {...colorScheme.set('backgroundColor', 'divider')}
+        ></div>
+        <div {...styles.left}>
+          <div
+            {...styles.bar}
+            {...colorScheme.set('backgroundColor', 'sequential60')}
+            style={{
               right: 0,
               width: `${truePercent}%`,
-              backgroundColor: 'rgb(75,151,201)',
               direction: 'rtl',
               textAlign: 'left',
-            }}>
-              <span style={{ marginLeft: userAnswerTrue ? -CIRCLE_SIZE : 0 }}>
-                <label {...styles.barLabel}>{t('questionnaire/question/choice/true', { value: truePercent })}</label>
-                { userAnswerTrue &&
-                  <CheckCircle {...styles.userAnswerIcon} size={CIRCLE_SIZE} color={colors.primary} />
-                }
-              </span>
-            </div>
+            }}
+          >
+            <span style={{ marginLeft: userAnswerTrue ? -CIRCLE_SIZE : 0 }}>
+              <label {...styles.barLabel}>
+                {t('questionnaire/question/choice/true', {
+                  value: truePercent,
+                })}
+              </label>
+              {userAnswerTrue && (
+                <CheckCircle
+                  {...styles.userAnswerIcon}
+                  size={CIRCLE_SIZE}
+                  color={colors.primary}
+                />
+              )}
+            </span>
           </div>
-          <div {...styles.right}>
-            <div {...styles.bar} style={{
+        </div>
+        <div
+          {...styles.barTick}
+          {...colorScheme.set('backgroundColor', 'divider')}
+        ></div>
+        <div {...styles.right}>
+          <div
+            {...styles.bar}
+            {...colorScheme.set('backgroundColor', 'opposite60')}
+            style={{
               left: 0,
               width: `${falsePercent}%`,
-              backgroundColor: '#ff7f0e',
               textAlign: 'right',
-            }}>
-              <span style={{ marginRight: userAnswerFalse ? -CIRCLE_SIZE : 0 }}>
-                <label {...styles.barLabel}>{t('questionnaire/question/choice/false', { value: falsePercent })}</label>
-                { userAnswerFalse &&
-                  <CheckCircle {...styles.userAnswerIcon} size={CIRCLE_SIZE} color={colors.primary} />
-                }
-              </span>
-            </div>
+            }}
+          >
+            <span style={{ marginRight: userAnswerFalse ? -CIRCLE_SIZE : 0 }}>
+              <label {...styles.barLabel}>
+                {t('questionnaire/question/choice/false', {
+                  value: falsePercent,
+                })}
+              </label>
+              {userAnswerFalse && (
+                <CheckCircle
+                  {...styles.userAnswerIcon}
+                  size={CIRCLE_SIZE}
+                  color={colors.primary}
+                />
+              )}
+            </span>
           </div>
         </div>
-        <div {...styles.labels}>
-          <label {...styles.label}>100%</label>
-          <label {...styles.label}>0%</label>
-          <label {...styles.label}>100%</label>
-        </div>
+        <div
+          {...styles.barTick}
+          {...colorScheme.set('backgroundColor', 'divider')}
+        ></div>
       </div>
-    )
-  }
+      <div {...styles.labels}>
+        <label {...styles.label}>100%</label>
+        <label {...styles.label}>0%</label>
+        <label {...styles.label}>100%</label>
+      </div>
+    </div>
+  )
 }
 
 export default withTranslations(Chart)


### PR DESCRIPTION
Add darkmode to QuestionTypeChoiceChart

- add color context
- make new ticks with 1px wide div tags and change the background color depending on color scheme
- change color of bars depending on color scheme

Before:
<img width="573" alt="Bildschirmfoto 2021-10-12 um 21 06 52" src="https://user-images.githubusercontent.com/11921821/137014531-c4ae576b-4c7b-400c-a324-05951c3bcd29.png">

After:
<img width="501" alt="Bildschirmfoto 2021-10-12 um 20 59 13" src="https://user-images.githubusercontent.com/11921821/137014567-2a75770a-e323-4622-ab6f-60bbf3d65072.png">

